### PR TITLE
fix(fetch): support new CSV header, time format

### DIFF
--- a/fetcher/kevuln.go
+++ b/fetcher/kevuln.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gocarina/gocsv"
 	"github.com/inconshreveable/log15"
+	"golang.org/x/xerrors"
 
 	"github.com/vulsio/go-kev/models"
 	"github.com/vulsio/go-kev/utils"
@@ -51,6 +52,10 @@ func FetchKEVuln() ([]models.KEVuln, error) {
 	for i := range vulns {
 		if hasZeroWidthSpace([]byte(vulns[i].CveID)) {
 			vulns[i].CveID = string(stripZeroWidthSpace([]byte(vulns[i].CveID)))
+		}
+
+		if vulns[i].CveID == "" {
+			return nil, xerrors.New("Failed to fetch vulnerability info. err: CVE-ID is empty. CSV format may have been changed.")
 		}
 	}
 

--- a/models/models.go
+++ b/models/models.go
@@ -25,15 +25,15 @@ func (f FetchMeta) OutDated() bool {
 // KEVuln : Known Exploited Vulnerabilities
 type KEVuln struct {
 	ID          int64      `json:"-"`
-	CveID       string     `gorm:"type:varchar(255);index:idx_kev_cve_id" csv:"CVE"`
-	Source      string     `gorm:"type:varchar(255)" csv:"Vendor/Project"`
-	Product     string     `gorm:"type:varchar(255)" csv:"Product"`
-	Title       string     `gorm:"type:varchar(255)" csv:"Vulnerability Name"`
-	AddedDate   KEVulnTime `gorm:"type:time" csv:"Date Added to Catalog"`
-	Description string     `gorm:"type:text" csv:"Short Description"`
-	Action      string     `gorm:"type:varchar(255)" csv:"Action"`
-	DueDate     KEVulnTime `gorm:"type:time" csv:"Due Date"`
-	Notes       string     `gorm:"type:text" csv:"Notes"`
+	CveID       string     `gorm:"type:varchar(255);index:idx_kev_cve_id" csv:"cveID"`
+	Source      string     `gorm:"type:varchar(255)" csv:"vendorProject"`
+	Product     string     `gorm:"type:varchar(255)" csv:"product"`
+	Title       string     `gorm:"type:varchar(255)" csv:"vulnerabilityName"`
+	AddedDate   KEVulnTime `gorm:"type:time" csv:"dateAdded"`
+	Description string     `gorm:"type:text" csv:"shortDescription"`
+	Action      string     `gorm:"type:varchar(255)" csv:"requiredAction"`
+	DueDate     KEVulnTime `gorm:"type:time" csv:"dueDate"`
+	Notes       string     `gorm:"type:text" csv:"notes"`
 }
 
 // KEVulnTime :
@@ -41,7 +41,7 @@ type KEVulnTime struct {
 	time.Time
 }
 
-const kevDateFormat = "2-Jan-06"
+const kevDateFormat = "1/2/2006"
 
 // UnmarshalCSV :
 func (date *KEVulnTime) UnmarshalCSV(csv string) (err error) {


### PR DESCRIPTION
# What did you implement:
Fetch is failing because the header and time format of the CSV used as the information source has been changed. This has been fixed.

If the CSV format has been changed and the CVEID has not been obtained, an error is returned.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## upstream/master
```console
$ go-kev fetch kevuln
$ sqlite3 go-kev.sqlite3
sqlite> SELECT * FROM ke_vulns LIMIT 3;
id|cve_id|source|product|title|added_date|description|action|due_date|notes
1|||||0001-01-01 00:00:00+00:00|||0001-01-01 00:00:00+00:00|
2|||||0001-01-01 00:00:00+00:00|||0001-01-01 00:00:00+00:00|
3|||||0001-01-01 00:00:00+00:00|||0001-01-01 00:00:00+00:00|
```

## MaineK00n/fix-fetch
```console
$ go-kev fetch kevuln
$ sqlite3 go-kev.sqlite3
sqlite> SELECT * FROM ke_vulns LIMIT 3;
id|cve_id|source|product|title|added_date|description|action|due_date|notes
1|CVE-2021-27104|Accellion|FTA|Accellion FTA OS Command Injection Vulnerability|2021-11-03 00:00:00+00:00|Accellion FTA 9_12_370 and earlier is affected by OS command execution via a crafted POST request to various admin endpoints.|Apply updates per vendor instructions.|2021-11-17 00:00:00+00:00|
2|CVE-2021-27102|Accellion|FTA|Accellion FTA OS Command Injection Vulnerability|2021-11-03 00:00:00+00:00|Accellion FTA 9_12_411 and earlier is affected by OS command execution via a local web service call.|Apply updates per vendor instructions.|2021-11-17 00:00:00+00:00|
3|CVE-2021-27101|Accellion|FTA|Accellion FTA SQL Injection Vulnerability|2021-11-03 00:00:00+00:00|Accellion FTA 9_12_370 and earlier is affected by SQL injection via a crafted Host header in a request to document_root.html.|Apply updates per vendor instructions.|2021-11-17 00:00:00+00:00|
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

