### PR TITLE
fix(fetch): change timeformat

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - '*'
 

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   golangci:

--- a/models/models.go
+++ b/models/models.go
@@ -41,15 +41,12 @@ type KEVulnTime struct {
 	time.Time
 }
 
-const kevDateFormat = "1/2/2006"
+const kevDateFormat = "2006-01-02"
 
 // UnmarshalCSV :
 func (date *KEVulnTime) UnmarshalCSV(csv string) (err error) {
 	date.Time, err = time.Parse(kevDateFormat, csv)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Scan :


### PR DESCRIPTION
# What did you implement:
Date Format has been changed from `1/2/2006` to `2006-01-02`.

Fixes #8 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## main
```console
$ go-kev fetch kevuln
INFO[12-22|01:21:26] Fetching Known Exploited Vulnerabilities 
INFO[12-22|01:21:26] Fetching                                 URL=https://www.cisa.gov/sites/default/files/csv/known_exploited_vulnerabilities.csv
Failed to fetch Known Exploited Vulnerabilities. err: record on line 0; parse error on line 2, column 5: parsing time "2021-11-03": month out of range
```

## MaineK00n/fix-timeformat
```console
$ go-kev fetch kevuln
INFO[12-22|01:21:47] Fetching Known Exploited Vulnerabilities 
INFO[12-22|01:21:47] Fetching                                 URL=https://www.cisa.gov/sites/default/files/csv/known_exploited_vulnerabilities.csv
INFO[12-22|01:21:47] Insert Known Exploited Vulnerabilities into go-kev. db=sqlite3
INFO[12-22|01:21:47] Inserting Known Exploited Vulnerabilities... 
311 / 311 [------------------------------------------------------] 100.00% ? p/s
INFO[12-22|01:21:47] CveID Count
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

