### PR TITLE
fix(server): fix time.Parse err at UnmarshalJSON

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -61,6 +61,10 @@ func (date *KEVulnTime) UnmarshalJSON(b []byte) error {
 
 	var err error
 	date.Time, err = time.Parse(`"`+kevDateFormat+`"`, string(b))
+	if _, ok := err.(*time.ParseError); !ok {
+		return err
+	}
+	date.Time, err = time.Parse(`"`+time.RFC3339+`"`, string(b))
 	return err
 }
 


### PR DESCRIPTION
# What did you implement:
Fix bug where UnmarshalJSON was failing due to differences in time format when searching in Redis.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ docker run --rm -d -p 127.0.0.1:6379:6379 redis
$ go-kev fetch kevuln --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ go-kev server --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ curl http://127.0.0.1:1328/cves/CVE-2021-27104 | jq
[
  {
    "cveID": "CVE-2021-27104",
    "vendorProject": "Accellion",
    "product": "FTA",
    "vulnerabilityName": "Accellion FTA OS Command Injection Vulnerability",
    "dateAdded": "2021-11-03T00:00:00Z",
    "shortDescription": "Accellion FTA 9_12_370 and earlier is affected by OS command execution via a crafted POST request to various admin endpoints.",
    "requiredAction": "Apply updates per vendor instructions.",
    "dueDate": "2021-11-17T00:00:00Z"
  }
]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

