### PR TITLE
fix type of requiredAction to allow longer contents, as Confluence security advisory is too long for varchar(255)

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -41,7 +41,7 @@ type KEVuln struct {
 	VulnerabilityName string     `gorm:"type:varchar(255)" json:"vulnerabilityName"`
 	DateAdded         KEVulnTime `gorm:"type:time" json:"dateAdded"`
 	ShortDescription  string     `gorm:"type:text" json:"shortDescription"`
-	RequiredAction    string     `gorm:"type:varchar(255)" json:"requiredAction"`
+	RequiredAction    string     `gorm:"type:text" json:"requiredAction"`
 	DueDate           KEVulnTime `gorm:"type:time" json:"dueDate"`
 }
 


### PR DESCRIPTION
# What did you implement:

We are using `go-kev` with Vuls to download the "known exploited vulnerabilities" from https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json. 

Since a few days, the inserting of the data into our Postgres server is failing:

```
t=2022-06-16T14:26:24+0000 lvl=info msg=Fetching URL=https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
t=2022-06-16T14:26:24+0000 lvl=info msg="Insert Known Exploited Vulnerabilities into go-kev." db=postgres
t=2022-06-16T14:26:24+0000 lvl=info msg="Inserting Known Exploited Vulnerabilities..."
Failed to insert. dbpath: postgresql://vuls-kevdb:***@postgres.default.svc.cluster.local:5432/vuls_kev, err: Failed to insert. err: ERROR: value too long for type character varying(255) (SQLSTATE 22001)
```

I have created a debugging script to see which column + value is breaking the ingestion, you can find it at: https://gist.github.com/tommartensen/bee4c442aafc8345abba71769597450d. 

From the output of this script, we see that `requiredAction` of `CVE-2022-26134` has a length of 369 characters, which is too long for `varchar(255)`.

I suggest to use type `text` instead, like is already done for `shortDescription`. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(-> not sure about this, see comment about DB schema update in next section)

# How Has This Been Tested?

`make test` has passed and we tested the ingestion with our setup. For that, we changed the column type in our Postgres database to `text`, not sure if that was necessary or your Go DB driver would do it automatically. 
 
```psql
ALTER TABLE ke_vulns ALTER COLUMN required_action TYPE text;
```

Happy to provide additional evidence, if you have further test cases.

Output of successful run: 

```
t=2022-06-20T07:06:55+0000 lvl=info msg="Fetching Known Exploited Vulnerabilities"
t=2022-06-20T07:06:55+0000 lvl=info msg=Fetching URL=https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
t=2022-06-20T07:06:55+0000 lvl=info msg="Insert Known Exploited Vulnerabilities into go-kev." db=postgres
t=2022-06-20T07:06:55+0000 lvl=info msg="Inserting Known Exploited Vulnerabilities..."
0 / 778 [______________________________________________________________________________] 0.00% ? p/s
0 / 778 [______________________________________________________________________________] 0.00% ? p/s
0 / 778 [______________________________________________________________________________] 0.00% ? p/s
778 / 778 [-----------------------------------------------------------------------] 100.00% 1448 p/s
t=2022-06-20T07:06:56+0000 lvl=info msg="CveID Count" count=778
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

